### PR TITLE
Feature/add ignore file list input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+real-diff.zip

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -10,6 +10,7 @@ export const HomeView = () => {
   const isPullRequestPath =
     useSelector(settingSelector.isPullRequestPath)
 
+  // FIXME: this component called twice
   useEffect(() => {
     dispatch(settingActions.requestPath())
     dispatch(settingActions.syncIgnoreFileList())

--- a/src/components/home/index.tsx
+++ b/src/components/home/index.tsx
@@ -12,6 +12,7 @@ export const HomeView = () => {
 
   useEffect(() => {
     dispatch(settingActions.requestPath())
+    dispatch(settingActions.syncIgnoreFileList())
   }, [dispatch])
 
 

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -34,11 +34,6 @@ export const FileListSettingView = () => {
   )
   const [fileNameToBeAdded, setFileNameToBeAdded] = useState('')
 
-  useEffect(() => {
-    return () => {
-      //dispatch()
-    }
-  }, [])
   const onKeyPressed = ({key}: KeyboardEvent<HTMLInputElement>) => {
     if (key === 'Enter') {
       addIgnoreFileName()

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+
+export const FileListSettingView = () => (
+  <div>FileListSettingView</div>
+)

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -24,7 +24,7 @@ const renderFileList = (
   onClickDelete: Function,
 ) => ({fileName}: IgnoredFile) => (
   <li key={fileName}>
-    <span onClick={ () => onClickDelete(fileName)}>X {' '}</span>
+    <button onClick={ () => onClickDelete(fileName)}>X {' '}</button>
     <span>{fileName}</span>
   </li>
 )

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -20,11 +20,13 @@ const AddButton = styled.button`
 `
 
 // TODO: 폴더를 나눌지 그냥 여기서 다 쓸지 고민해서 정하기.
-const renderFileList = (fileList: IgnoredFile[]) => (
-  fileList.map(
-    ({fileName, ignore}) => (
-      <li key={fileName}>{fileName}</li>
-    ))
+const renderFileList = (
+  onClickDelete: Function,
+) => ({fileName}: IgnoredFile) => (
+  <li key={fileName}>
+    <span onClick={ () => onClickDelete(fileName)}>X {' '}</span>
+    <span>{fileName}</span>
+  </li>
 )
 
 export const FileListSettingView = () => {
@@ -39,6 +41,11 @@ export const FileListSettingView = () => {
       addIgnoreFileName()
     }
   }
+
+  const removeItem = (fileName: string) => {
+    dispatch(settingActions.removeIgnoreFile(fileName))
+  }
+
   const addIgnoreFileName = () => {
     setFileNameToBeAdded('')
     dispatch(settingActions.addIgnoreFile({
@@ -50,7 +57,11 @@ export const FileListSettingView = () => {
   return (
     <>
       <div>FileListSettingView</div>
-      <ol>{renderFileList(ignoreFileList)}</ol>
+      <ol>
+        {
+          ignoreFileList.map(renderFileList(removeItem))
+        }
+      </ol>
       <InputWrapper>
         <input
           value={fileNameToBeAdded}

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
-import React, { KeyboardEvent,useEffect,useState } from 'react'
+import React, { KeyboardEvent, useState } from 'react'
 import { useDispatch,useSelector } from 'react-redux'
 
 import { IgnoredFile } from '@/domain/ignoreFile'
-import { settingSelector } from '@/features/settingSlice'
+import { settingActions,settingSelector } from '@/features/settingSlice'
 
 const InputWrapper = styled.div`
   display: flex;
@@ -41,7 +41,10 @@ export const FileListSettingView = () => {
   }
   const addIgnoreFileName = () => {
     setFileNameToBeAdded('')
-    // TODO: Add add file name dispatch event
+    dispatch(settingActions.addIgnoreFile({
+      fileName: fileNameToBeAdded,
+      ignore: true,
+    }))
   }
 
   return (

--- a/src/components/settings/FileList.tsx
+++ b/src/components/settings/FileList.tsx
@@ -1,6 +1,68 @@
-import React from 'react'
+import styled from '@emotion/styled'
+import React, { KeyboardEvent,useEffect,useState } from 'react'
+import { useDispatch,useSelector } from 'react-redux'
 
+import { IgnoredFile } from '@/domain/ignoreFile'
+import { settingSelector } from '@/features/settingSlice'
 
-export const FileListSettingView = () => (
-  <div>FileListSettingView</div>
+const InputWrapper = styled.div`
+  display: flex;
+`
+
+// TODO: Refactor to shared button
+const AddButton = styled.button`
+  padding: 8px 0px;
+  margin-top: 10px;
+  background: rgba(24,205,140,0.1);
+  border-radius: 8px;
+  color: #18CD8C;
+  font-size: 14px;
+`
+
+// TODO: 폴더를 나눌지 그냥 여기서 다 쓸지 고민해서 정하기.
+const renderFileList = (fileList: IgnoredFile[]) => (
+  fileList.map(
+    ({fileName, ignore}) => (
+      <li key={fileName}>{fileName}</li>
+    ))
 )
+
+export const FileListSettingView = () => {
+  const dispatch = useDispatch()
+  const ignoreFileList = useSelector(
+    settingSelector.ignoreFileList,
+  )
+  const [fileNameToBeAdded, setFileNameToBeAdded] = useState('')
+
+  useEffect(() => {
+    return () => {
+      //dispatch()
+    }
+  }, [])
+  const onKeyPressed = ({key}: KeyboardEvent<HTMLInputElement>) => {
+    if (key === 'Enter') {
+      addIgnoreFileName()
+    }
+  }
+  const addIgnoreFileName = () => {
+    setFileNameToBeAdded('')
+    // TODO: Add add file name dispatch event
+  }
+
+  return (
+    <>
+      <div>FileListSettingView</div>
+      <ol>{renderFileList(ignoreFileList)}</ol>
+      <InputWrapper>
+        <input
+          value={fileNameToBeAdded}
+          onChange={({target}) =>
+            setFileNameToBeAdded(target.value)
+          }
+          onKeyPress={onKeyPressed}
+        />
+        <AddButton onClick={addIgnoreFileName}>ADD</AddButton>
+      </InputWrapper>
+    </>
+  )
+}

--- a/src/components/settings/Token.tsx
+++ b/src/components/settings/Token.tsx
@@ -35,7 +35,7 @@ const SaveButton = styled.button`
   font-size: 14px;
 `
 // https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
-export const TokenSettingsView = () => {
+export const TokenSettingView = () => {
   const dispatch = useDispatch()
   const [token, setToken] = useState('')
 

--- a/src/components/settings/Token.tsx
+++ b/src/components/settings/Token.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
 
 import { settingActions } from '@/features/settingSlice'
 
@@ -16,9 +15,6 @@ const Header = styled.header`
 const Head = styled.h1`
   font-weight: 700;
   margin: 10px 0;
-`
-const CloseButton = styled(Link)`
-  color: gray;
 `
 const TextInputField = styled.input`
   display: block;
@@ -48,7 +44,6 @@ export const TokenSettingView = () => {
     <Layout>
       <Header>
         <Head>Add GitHub API Token</Head>
-        <CloseButton to='/'>X</CloseButton>
       </Header>
       <TextInputField
         value={token}

--- a/src/components/settings/Token.tsx
+++ b/src/components/settings/Token.tsx
@@ -24,6 +24,7 @@ const TextInputField = styled.input`
   display: block;
   width: 100%;
 `
+// TODO: Refactor to shared button
 const SaveButton = styled.button`
   padding: 8px 0px;
   margin-top: 10px;

--- a/src/components/settings/Token.tsx
+++ b/src/components/settings/Token.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled'
+import React, { useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { Link } from 'react-router-dom'
+
+import { settingActions } from '@/features/settingSlice'
+
+const Layout = styled.div`
+  margin: 10px;
+  width: 280px;
+`
+
+const Header = styled.header`
+  display: flex;
+`
+const Head = styled.h1`
+  font-weight: 700;
+  margin: 10px 0;
+`
+const CloseButton = styled(Link)`
+  color: gray;
+`
+const TextInputField = styled.input`
+  display: block;
+  width: 100%;
+`
+const SaveButton = styled.button`
+  padding: 8px 0px;
+  margin-top: 10px;
+  width: 100%;
+  background: rgba(24,205,140,0.1);
+  border-radius: 8px;
+  color: #18CD8C;
+  font-weight: bold;
+  font-size: 14px;
+`
+// https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
+export const TokenSettingsView = () => {
+  const dispatch = useDispatch()
+  const [token, setToken] = useState('')
+
+  const saveToken = () => {
+    dispatch(settingActions.saveToken(token))
+  }
+
+  return (
+    <Layout>
+      <Header>
+        <Head>Add GitHub API Token</Head>
+        <CloseButton to='/'>X</CloseButton>
+      </Header>
+      <TextInputField
+        value={token}
+        onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
+          setToken(target.value)
+        }
+      />
+      <SaveButton onClick={saveToken}>Save</SaveButton>
+    </Layout>
+  )
+}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import { NavLink,Route, Switch } from 'react-router-dom'
+import { NavLink,Route, Switch, useRouteMatch } from 'react-router-dom'
+
+import { SETTING_ROUTE_TYPE } from '@/constants/routes'
 
 import { FileListSettingView } from './FileList'
 import { TokenSettingView } from './Token'
@@ -18,19 +20,34 @@ const StickyNav = styled.header`
 
 // https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
 export const SettingsView = () => {
+  const match = useRouteMatch()
+
+//'/settings/file-list'
   return (
     <>
       <StickyNav>
-        <StyledNavLink activeClassName='active' to='/settings/file-list'>
+        <StyledNavLink
+          activeClassName='active'
+          to={`${match.url}/${SETTING_ROUTE_TYPE.FILE_LIST}`}
+        >
           Files
         </StyledNavLink >
-        <StyledNavLink activeClassName='active' to='/settings/token'>
+        <StyledNavLink
+          activeClassName='active'
+          to={`${match.url}/${SETTING_ROUTE_TYPE.TOKEN}`}
+        >
           Token
         </StyledNavLink >
       </StickyNav>
       <Switch>
-        <Route path='/settings/token' component={TokenSettingView} />
-        <Route path='/settings/file-list' component={FileListSettingView} />
+        <Route
+          path={`${match.url}/${SETTING_ROUTE_TYPE.FILE_LIST}`}
+          component={TokenSettingView}
+        />
+        <Route
+          path={`${match.url}/${SETTING_ROUTE_TYPE.TOKEN}`}
+          component={FileListSettingView}
+        />
       </Switch>
     </>
   )

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,61 +1,37 @@
 import styled from '@emotion/styled'
-import React, { useState } from 'react'
-import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
+import React from 'react'
+import { NavLink,Route, Switch } from 'react-router-dom'
 
-import { settingActions } from '@/features/settingSlice'
+import { FileListSettingView } from './FileList'
+import { TokenSettingsView } from './Token'
 
-const Layout = styled.div`
-  margin: 10px;
-  width: 280px;
+const StyledNavLink = styled(NavLink)`
+  &.active {
+    color: #18CD8C;
+  }
 `
 
-const Header = styled.header`
+const StickyNav = styled.header`
   display: flex;
+  justify-content: space-around;
 `
-const Head = styled.h1`
-  font-weight: 700;
-  margin: 10px 0;
-`
-const CloseButton = styled(Link)`
-  color: gray;
-`
-const TextInputField = styled.input`
-  display: block;
-  width: 100%;
-`
-const SaveButton = styled.button`
-  padding: 8px 0px;
-  margin-top: 10px;
-  width: 100%;
-  background: rgba(24,205,140,0.1);
-  border-radius: 8px;
-  color: #18CD8C;
-  font-weight: bold;
-  font-size: 14px;
-`
+
 // https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
 export const SettingsView = () => {
-  const dispatch = useDispatch()
-  const [token, setToken] = useState('')
-
-  const saveToken = () => {
-    dispatch(settingActions.saveToken(token))
-  }
-
   return (
-    <Layout>
-      <Header>
-        <Head>Add GitHub API Token</Head>
-        <CloseButton to='/'>X</CloseButton>
-      </Header>
-      <TextInputField
-        value={token}
-        onChange={({ target }: React.ChangeEvent<HTMLInputElement>) =>
-          setToken(target.value)
-        }
-      />
-      <SaveButton onClick={saveToken}>Save</SaveButton>
-    </Layout>
+    <>
+      <StickyNav>
+        <StyledNavLink activeClassName='active' to='/settings/file-list'>
+          Files
+        </StyledNavLink >
+        <StyledNavLink activeClassName='active' to='/settings/token'>
+          Token
+        </StyledNavLink >
+      </StickyNav>
+      <Switch>
+        <Route path='/settings/token' component={TokenSettingsView} />
+        <Route path='/settings/file-list' component={FileListSettingView} />
+      </Switch>
+    </>
   )
 }

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { NavLink,Route, Switch } from 'react-router-dom'
 
 import { FileListSettingView } from './FileList'
-import { TokenSettingsView } from './Token'
+import { TokenSettingView } from './Token'
 
 const StyledNavLink = styled(NavLink)`
   &.active {
@@ -29,7 +29,7 @@ export const SettingsView = () => {
         </StyledNavLink >
       </StickyNav>
       <Switch>
-        <Route path='/settings/token' component={TokenSettingsView} />
+        <Route path='/settings/token' component={TokenSettingView} />
         <Route path='/settings/file-list' component={FileListSettingView} />
       </Switch>
     </>

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import { NavLink,Route, Switch, useRouteMatch } from 'react-router-dom'
+import { Link,NavLink,Route, Switch, useRouteMatch } from 'react-router-dom'
 
 import { SETTING_ROUTE_TYPE } from '@/constants/routes'
 
@@ -18,11 +18,13 @@ const StickyNav = styled.header`
   justify-content: space-around;
 `
 
-// https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
+const CloseButton = styled(Link)`
+  color: gray;
+`
+
 export const SettingsView = () => {
   const match = useRouteMatch()
 
-//'/settings/file-list'
   return (
     <>
       <StickyNav>
@@ -38,15 +40,16 @@ export const SettingsView = () => {
         >
           Token
         </StyledNavLink >
+        <CloseButton to='/'>X</CloseButton>
       </StickyNav>
       <Switch>
         <Route
           path={`${match.url}/${SETTING_ROUTE_TYPE.FILE_LIST}`}
-          component={TokenSettingView}
+          component={FileListSettingView}
         />
         <Route
           path={`${match.url}/${SETTING_ROUTE_TYPE.TOKEN}`}
-          component={FileListSettingView}
+          component={TokenSettingView}
         />
       </Switch>
     </>

--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
+import { ROUTE } from '@/constants/routes'
+
 export const Footer = () => {
   return (
-    <Link to='/settings'>Setting</Link>
+    <Link to={ROUTE.SETTINGS}>Setting</Link>
   )
 }

--- a/src/components/shared/Footer.tsx
+++ b/src/components/shared/Footer.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import { ROUTE } from '@/constants/routes'
+import { ROUTE, SETTING_ROUTE_TYPE } from '@/constants/routes'
 
 export const Footer = () => {
   return (
-    <Link to={ROUTE.SETTINGS}>Setting</Link>
+    <Link to={`${ROUTE.SETTINGS}/${SETTING_ROUTE_TYPE.TOKEN}`}>Setting</Link>
   )
 }

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,10 @@
+export const ROUTE = {
+  SETTINGS: '/settings',
+  MAIN: '/main',
+  HOME: '/',
+}
+
+export const SETTING_ROUTE_TYPE = {
+  TOKEN: 'token',
+  FILE_LIST: 'fileList',
+}

--- a/src/domain/ignoreFile.ts
+++ b/src/domain/ignoreFile.ts
@@ -1,0 +1,4 @@
+export interface IgnoredFile {
+  fileName: string;
+  ignore: boolean;
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -5,7 +5,7 @@ import { all } from 'redux-saga/effects'
 
 import { watchFetchPullRequest } from './prSaga'
 import { PR_SLICE,prReducer } from './prSlice'
-import { watchRequestPath,watchSaveUserToken } from './settingSaga'
+import { watchRequestPath,watchSaveUserToken, watchSyncIgnoreFileList } from './settingSaga'
 import { settingReducer,USER_INFO } from './settingSlice'
 
 const rootReducer = combineReducers({
@@ -19,6 +19,7 @@ export function* rootSaga() {
     watchSaveUserToken(),
     watchFetchPullRequest(),
     watchRequestPath(),
+    watchSyncIgnoreFileList(),
   ])
 }
 

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -5,7 +5,7 @@ import { all } from 'redux-saga/effects'
 
 import { watchFetchPullRequest } from './prSaga'
 import { PR_SLICE,prReducer } from './prSlice'
-import { watchRequestPath,watchSaveUserToken, watchSyncIgnoreFileList } from './settingSaga'
+import { watchAddIgnoreFile,watchRequestPath,watchSaveUserToken, watchSyncIgnoreFileList } from './settingSaga'
 import { settingReducer,USER_INFO } from './settingSlice'
 
 const rootReducer = combineReducers({
@@ -20,6 +20,7 @@ export function* rootSaga() {
     watchFetchPullRequest(),
     watchRequestPath(),
     watchSyncIgnoreFileList(),
+    watchAddIgnoreFile(),
   ])
 }
 

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -5,7 +5,7 @@ import { all } from 'redux-saga/effects'
 
 import { watchFetchPullRequest } from './prSaga'
 import { PR_SLICE,prReducer } from './prSlice'
-import { watchAddIgnoreFile,watchRequestPath,watchSaveUserToken, watchSyncIgnoreFileList } from './settingSaga'
+import { watchAddIgnoreFile,watchRemoveIgnoreFile,watchRequestPath,watchSaveUserToken, watchSyncIgnoreFileList } from './settingSaga'
 import { settingReducer,USER_INFO } from './settingSlice'
 
 const rootReducer = combineReducers({
@@ -21,6 +21,7 @@ export function* rootSaga() {
     watchRequestPath(),
     watchSyncIgnoreFileList(),
     watchAddIgnoreFile(),
+    watchRemoveIgnoreFile(),
   ])
 }
 

--- a/src/features/prSaga.ts
+++ b/src/features/prSaga.ts
@@ -1,6 +1,7 @@
 import { call,put,select, takeLatest } from 'redux-saga/effects'
 
 import { pullRequestAPI } from '@/api'
+import { IgnoredFile } from '@/domain/ignoreFile'
 import { PullRequestData } from '@/domain/pullRequest'
 import { settingSelector } from '@/features/settingSlice'
 import { redirect } from '@/utils/history'
@@ -47,12 +48,11 @@ function* fetchPullRequestFiles() {
       totalAdditions: 0,
       totalDeletions:0,
     })
+    const ignoreFileList: IgnoredFile[] = yield select(
+      settingSelector.ignoreFileList,
+    )
 
-    const filterFiles = filterIgnoredFiles([
-      'package-lock.json',
-      'yarn.lock',
-    ])
-
+    const filterFiles = filterIgnoredFiles(ignoreFileList.map(file => file.fileName))
     const {
       ignoredAdditions,
       ignoredDeletions,

--- a/src/features/prSaga.ts
+++ b/src/features/prSaga.ts
@@ -1,6 +1,7 @@
 import { call,put,select, takeLatest } from 'redux-saga/effects'
 
 import { pullRequestAPI } from '@/api'
+import { ROUTE, SETTING_ROUTE_TYPE } from '@/constants/routes'
 import { IgnoredFile } from '@/domain/ignoreFile'
 import { PullRequestData } from '@/domain/pullRequest'
 import { settingSelector } from '@/features/settingSlice'
@@ -75,7 +76,7 @@ function* fetchPullRequestFiles() {
     yield put(prActions.setRealDiff(realDiff))
   } catch(error) {
     console.log('@@@ error !!!!',error)
-    yield call(redirect, '/settings')
+    yield call(redirect, `/${ROUTE.SETTINGS}/${SETTING_ROUTE_TYPE.TOKEN}`)
   }
 }
 

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -59,18 +59,14 @@ export function* watchRequestPath() {
 }
 
 function* syncIgnoreFileFromStorage() {
-  console.log('Saga called')
   const initialFileList = yield select(
     settingSelector.ignoreFileList,
   )
-  console.log('@@ initialFileList', initialFileList)
   const storedIgnoreList = yield call(
     storageUtil.getData,
     STORAGE_KEY.IGNORE_FILE_LIST,
   )
-  console.log('@@ storedIgnoreList', storedIgnoreList)
   if (!storedIgnoreList) {
-    console.log('@@ isEmpty')
     yield call(
       storageUtil.saveData,
       STORAGE_KEY.IGNORE_FILE_LIST,

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -2,6 +2,7 @@ import { PayloadAction } from '@reduxjs/toolkit'
 import { call,put,select,takeLatest } from 'redux-saga/effects'
 
 import { FetchStatusCode } from '@/api'
+import { IgnoredFile } from '@/domain/ignoreFile'
 import { PULL_REQUEST_REGEX } from '@/domain/pullRequest'
 import { currentPath,redirect } from '@/utils/history'
 import { STORAGE_KEY,storageUtil } from '@/utils/storage'
@@ -90,5 +91,23 @@ export function* watchSyncIgnoreFileList() {
   yield takeLatest(
     settingActions.syncIgnoreFileList,
     syncIgnoreFileFromStorage,
+  )
+}
+
+function* addIgnoreFileToStorage({payload}: PayloadAction<IgnoredFile>) {
+  const existFileList: IgnoredFile[] = yield select(
+    settingSelector.ignoreFileList,
+  )
+  yield call(
+    storageUtil.saveData,
+    STORAGE_KEY.IGNORE_FILE_LIST,
+    existFileList.concat(payload),
+  )
+}
+
+export function* watchAddIgnoreFile() {
+  yield takeLatest(
+    settingActions.addIgnoreFile,
+    addIgnoreFileToStorage,
   )
 }

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -4,7 +4,6 @@ import { call,put,select,takeLatest } from 'redux-saga/effects'
 import { FetchStatusCode } from '@/api'
 import { PULL_REQUEST_REGEX } from '@/domain/pullRequest'
 import { currentPath,redirect } from '@/utils/history'
-import { isEmpty } from '@/utils/iter'
 import { STORAGE_KEY,storageUtil } from '@/utils/storage'
 import { isMatchedPattern } from '@/utils/validation'
 
@@ -59,15 +58,18 @@ export function* watchRequestPath() {
 }
 
 function* syncIgnoreFileFromStorage() {
+  console.log('Saga called')
   const initialFileList = yield select(
     settingSelector.ignoreFileList,
   )
+  console.log('@@ initialFileList', initialFileList)
   const storedIgnoreList = yield call(
     storageUtil.getData,
     STORAGE_KEY.IGNORE_FILE_LIST,
   )
-
-  if (isEmpty(storedIgnoreList)) {
+  console.log('@@ storedIgnoreList', storedIgnoreList)
+  if (!storedIgnoreList) {
+    console.log('@@ isEmpty')
     yield call(
       storageUtil.saveData,
       STORAGE_KEY.IGNORE_FILE_LIST,
@@ -78,7 +80,9 @@ function* syncIgnoreFileFromStorage() {
   }
 
   yield put(
-    settingActions.setIgnoreFileListSuccess(storedIgnoreList),
+    settingActions.setIgnoreFileListSuccess(
+      storedIgnoreList,
+    ),
   )
 }
 

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -114,9 +114,8 @@ export function* watchAddIgnoreFile() {
 
 function* removeIgnoreFileFromStorage({payload}: PayloadAction<string>) {
   const currentFileList: IgnoredFile[] = yield select(settingSelector.ignoreFileList)
-
   const updatedFileList = currentFileList.filter(
-    ({fileName}) => fileName === payload,
+    ({fileName}) => fileName !== payload,
   )
 
   yield call(

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -115,8 +115,9 @@ export function* watchAddIgnoreFile() {
 function* removeIgnoreFileFromStorage({payload}: PayloadAction<string>) {
   const currentFileList: IgnoredFile[] = yield select(settingSelector.ignoreFileList)
 
-  const idx = currentFileList.findIndex(file => file.fileName === payload)
-  const updatedFileList = currentFileList.splice(idx, 1)
+  const updatedFileList = currentFileList.filter(
+    ({fileName}) => fileName === payload,
+  )
 
   yield call(
     storageUtil.saveData,

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -111,3 +111,25 @@ export function* watchAddIgnoreFile() {
     addIgnoreFileToStorage,
   )
 }
+
+function* removeIgnoreFileFromStorage({payload}: PayloadAction<string>) {
+  const currentFileList: IgnoredFile[] = yield select(settingSelector.ignoreFileList)
+
+  const idx = currentFileList.findIndex(file => file.fileName === payload)
+  const updatedFileList = currentFileList.splice(idx, 1)
+
+  yield call(
+    storageUtil.saveData,
+    STORAGE_KEY.IGNORE_FILE_LIST,
+    updatedFileList,
+  )
+
+  yield put(settingActions.setIgnoreFileListSuccess(updatedFileList))
+}
+
+export function* watchRemoveIgnoreFile() {
+  yield takeLatest(
+    settingActions.removeIgnoreFile,
+    removeIgnoreFileFromStorage,
+  )
+}

--- a/src/features/settingSaga.ts
+++ b/src/features/settingSaga.ts
@@ -1,13 +1,14 @@
 import { PayloadAction } from '@reduxjs/toolkit'
-import { call,put,takeLatest } from 'redux-saga/effects'
+import { call,put,select,takeLatest } from 'redux-saga/effects'
 
 import { FetchStatusCode } from '@/api'
 import { PULL_REQUEST_REGEX } from '@/domain/pullRequest'
 import { currentPath,redirect } from '@/utils/history'
+import { isEmpty } from '@/utils/iter'
 import { STORAGE_KEY,storageUtil } from '@/utils/storage'
 import { isMatchedPattern } from '@/utils/validation'
 
-import { settingActions } from './settingSlice'
+import { settingActions, settingSelector } from './settingSlice'
 
 function* saveUserToken({payload}: PayloadAction<string>) {
   yield call(
@@ -54,5 +55,36 @@ export function* watchRequestPath() {
   yield takeLatest(
     settingActions.requestPath,
     getCurrentPath,
+  )
+}
+
+function* syncIgnoreFileFromStorage() {
+  const initialFileList = yield select(
+    settingSelector.ignoreFileList,
+  )
+  const storedIgnoreList = yield call(
+    storageUtil.getData,
+    STORAGE_KEY.IGNORE_FILE_LIST,
+  )
+
+  if (isEmpty(storedIgnoreList)) {
+    yield call(
+      storageUtil.saveData,
+      STORAGE_KEY.IGNORE_FILE_LIST,
+      initialFileList,
+    )
+
+    return
+  }
+
+  yield put(
+    settingActions.setIgnoreFileListSuccess(storedIgnoreList),
+  )
+}
+
+export function* watchSyncIgnoreFileList() {
+  yield takeLatest(
+    settingActions.syncIgnoreFileList,
+    syncIgnoreFileFromStorage,
   )
 }

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -61,6 +61,9 @@ const reducers = {
     state.ignoreFileList.value = initialState.ignoreFileList.value
     state.ignoreFileList.fetchState = payload
   },
+  addIgnoreFile: (state: SettingInfoState, { payload }: PayloadAction<IgnoredFile>) => {
+    // empty action
+  },
 }
 
 const sliceName = 'userInfo'

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -62,7 +62,7 @@ const reducers = {
     state.ignoreFileList.fetchState = payload
   },
   addIgnoreFile: (state: SettingInfoState, { payload }: PayloadAction<IgnoredFile>) => {
-    // empty action
+    state.ignoreFileList.value.push(payload)
   },
 }
 

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -51,7 +51,7 @@ const reducers = {
     state.path.value = initialState.path.value
     state.path.fetchState = payload
   },
-  requestIgnoreFileList: (state: SettingInfoState) => {
+  syncIgnoreFileList: (state: SettingInfoState) => {
     state.ignoreFileList.fetchState = FetchStatusCode.LOADING
   },
   setIgnoreFileListSuccess: (state: SettingInfoState, { payload }: PayloadAction<IgnoredFile[]>) => {

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -1,6 +1,7 @@
 import { createSelector,createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { FetchStatusCode } from '@/api'
+import { IgnoredFile } from '@/domain/ignoreFile'
 import { PathData } from '@/domain/pullRequest'
 
 import { RootState } from '.'
@@ -11,6 +12,7 @@ interface ResponseData<T> {
 }
 interface SettingInfoState {
   path: ResponseData<PathData>
+  ignoreFileList: ResponseData<IgnoredFile[]>
 }
 
 const initialState: SettingInfoState = {
@@ -22,11 +24,18 @@ const initialState: SettingInfoState = {
     },
     fetchState: FetchStatusCode.LOADING,
   },
+  ignoreFileList: {
+    value: [
+      {ignore: true, fileName: 'package-lock.json'},
+      {ignore: true, fileName: 'yarn.lock'},
+    ],
+    fetchState: FetchStatusCode.LOADING,
+  },
 }
 
 const reducers = {
   saveToken: (state: SettingInfoState, { payload }: PayloadAction<string>) => {
-    // state.token.value = payload
+    // empty action
   },
   requestPath: (state: SettingInfoState) => {
     state.path.fetchState = FetchStatusCode.LOADING
@@ -41,6 +50,16 @@ const reducers = {
   setPathFail: (state: SettingInfoState, { payload }: PayloadAction<FetchStatusCode>) => {
     state.path.value = initialState.path.value
     state.path.fetchState = payload
+  },
+  requestIgnoreFileList: (state: SettingInfoState) => {
+    state.ignoreFileList.fetchState = FetchStatusCode.LOADING
+  },
+  setIgnoreFileListSuccess: (state: SettingInfoState, { payload }: PayloadAction<IgnoredFile[]>) => {
+    state.ignoreFileList.value = payload
+  },
+  setIgnoreFileListFail: (state: SettingInfoState, { payload }: PayloadAction<FetchStatusCode>) => {
+    state.ignoreFileList.value = initialState.ignoreFileList.value
+    state.ignoreFileList.fetchState = payload
   },
 }
 

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -74,9 +74,13 @@ const getIsPullRequestPath = (state: SettingInfoState) => (
   state.path.fetchState === FetchStatusCode.OK
 )
 const getPathValue = (state: SettingInfoState) => state.path.value
+const getIgnoreFileList = (state: SettingInfoState) => {
+  return state.ignoreFileList.value
+}
 
 export const settingSelector = {
   path: createSelector([settingState], getPathValue),
+  ignoreFileList: createSelector([settingState], getIgnoreFileList),
   isPullRequestPath: createSelector([settingState], getIsPullRequestPath),
 }
 

--- a/src/features/settingSlice.ts
+++ b/src/features/settingSlice.ts
@@ -64,6 +64,9 @@ const reducers = {
   addIgnoreFile: (state: SettingInfoState, { payload }: PayloadAction<IgnoredFile>) => {
     state.ignoreFileList.value.push(payload)
   },
+  removeIgnoreFile: (state: SettingInfoState, { payload }: PayloadAction<string>) => {
+    // empty action
+  },
 }
 
 const sliceName = 'userInfo'

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,8 @@ import { SettingsView } from '@/components/settings/index'
 import store, { rootSaga,sagaMiddleware } from '@/features'
 import { history} from '@/utils/history'
 
+import { ROUTE } from './constants/routes'
+
 sagaMiddleware.run(rootSaga)
 
 const Layout = styled.div`
@@ -22,9 +24,9 @@ ReactDOM.render(
     <Layout>
       <Router history={history}>
         <Switch>
-          <Route path='/settings' component={SettingsView} />
-          <Route path='/main' component={MainView} />
-          <Route path='/' component={HomeView} />
+          <Route path={ROUTE.SETTINGS} component={SettingsView} />
+          <Route path={ROUTE.MAIN} component={MainView} />
+          <Route path={ROUTE.HOME} component={HomeView} />
         </Switch>
       </Router>
     </Layout>

--- a/src/utils/ignoredFileFilter.ts
+++ b/src/utils/ignoredFileFilter.ts
@@ -5,7 +5,9 @@ const getLastItem = <T>(arr: T[]) => {
 const getFileName = (fileNameWithPath: string) => {
   return getLastItem(fileNameWithPath.split('/'))
 }
-
+/*
+['package-lock.json', 'yarn.lock', '.gitignore']
+*/
 export const filterIgnoredFiles = (ignoredList: string[]) => (
   filename: string,
 ) => {

--- a/src/utils/iter.ts
+++ b/src/utils/iter.ts
@@ -1,0 +1,3 @@
+export const isEmpty = (iter: any[] | Record<string, any>) => (
+  Object.keys(iter).length === 0
+)

--- a/src/utils/iter.ts
+++ b/src/utils/iter.ts
@@ -1,3 +1,0 @@
-export const isEmpty = (iter: any[] | Record<string, any>) => (
-  Object.keys(iter).length === 0
-)

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -5,7 +5,7 @@ export enum STORAGE_KEY {
 
 const saveData = <T>(key: STORAGE_KEY, value: T) => new Promise<void>((resolve) => {
   chrome.storage.sync.set({[key]: value}, function () {
-    return resolve(console.log('🚀 Token Saved!'))
+    return resolve(console.log('🚀 Storage Updated!'))
   })
 })
 // FIXME: type

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -8,8 +8,8 @@ const saveData = <T>(key: STORAGE_KEY, value: T) => new Promise<void>((resolve) 
     return resolve(console.log('🚀 Storage Updated!'))
   })
 })
-// FIXME: type
-const getData = <T>(key: STORAGE_KEY): any => new Promise<any>((resolve) => {
+
+const getData = <T>(key: STORAGE_KEY): Promise<T> => new Promise<T>((resolve) => {
   chrome.storage.sync.get(key, function (items) {
 
     return resolve(items[key])

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 export enum STORAGE_KEY {
   GITHUB_TOKEN = '@@REAL_DIFF/GITHUB_TOKEN',
+  IGNORE_FILE_LIST = '@@REAL_DIFF/IGNORE_FILE_LIST',
 }
 
 const saveData = <T>(key: STORAGE_KEY, value: T) => new Promise<void>((resolve) => {


### PR DESCRIPTION
## Desc

![image](https://user-images.githubusercontent.com/18658235/88454837-18dca980-cead-11ea-8c93-8efe9d18eebb.png)

어떤 파일의 file changed line을 무시할지 커스텀하게 인풋받기. 

- Settings View에 NavLink로 route 나누기
- 무시하고자 하는 파일 목록을 chrome app storage에 저장
- 최초 익스텐션 load시에 chrome app storage에서 sync해서 가져와야하나...? 🤔 

## TODO

- [x] custom으로 추가한 내용이 filter계산에서 안빠지는 버그 테스트 후 수정 
- [x] 삭제도 되어야 하지 않을까..